### PR TITLE
Version bump to 5.2.2 with dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>foundation</artifactId>
-    <version>5.0.3-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
     <name>Foundation</name>
     <description>WebJar for Foundation</description>
     <url>http://webjars.org</url>
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>modernizr</artifactId>
-            <version>2.6.2-1</version>
+            <version>2.7.1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>fastclick</artifactId>
-            <version>0.6.11</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
@@ -68,12 +68,12 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery-cookie</artifactId>
-            <version>1.3.1</version>
+            <version>1.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>2.0.3-1</version>
+            <version>2.1.0-2</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
@@ -89,7 +89,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstreamVersion>5.0.3</upstreamVersion>
+        <upstreamVersion>5.2.2</upstreamVersion>
         <sourceUrl>https://github.com/zurb/foundation/archive</sourceUrl>
         <releaseUrl>http://foundation.zurb.com/cdn/releases</releaseUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstreamVersion}</destDir>


### PR DESCRIPTION
Has a dependency on the fastclick version update in https://github.com/webjars/fastclick/pull/2
